### PR TITLE
ListenAddr instead of listenAdrr

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Config struct {
-	listenAddr 		string
+	ListenAddr 		string
 	FTPRoot			string
 	DBpath 			string	
 }
@@ -14,7 +14,7 @@ type Config struct {
 
 func Load() (*Config, error) {
 	config := &Config{
-        listenAddr:     getEnv("LISTEN_ADDR" , ":2121"), 
+        ListenAddr:     getEnv("LISTEN_ADDR" , ":2121"), 
         FTPRoot:        getEnv("FTP_ROOT", "./"),
         DBpath:         getEnv("DB_PATH", "./ftp.db"),
     }


### PR DESCRIPTION
listenAddr was not exported because of starting with lowercase 

```go
type Config struct {
	ListenAddr 		string //not  listenAddr
	FTPRoot		string
	DBpath 			string	
}
```

also here : 

```go
config := &Config{
        ListenAddr:     getEnv("LISTEN_ADDR" , ":2121"), 
        FTPRoot:        getEnv("FTP_ROOT", "./"),
        DBpath:         getEnv("DB_PATH", "./ftp.db"),
  }
```